### PR TITLE
Phase 10: Add announcement link empty states with humorous messages

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -3516,3 +3516,219 @@ p.origin-placeholder {
 .text-center {
   text-align: center;
 }
+
+/* =============================================================================
+   MESSAGE PAGE COMPONENTS
+   Humorous dead-end message page with timer and exit button
+   Used by message.html for announcement link empty states
+   ============================================================================= */
+
+/**
+ * Message Container
+ * Full-page layout for message display
+ * Centers content both vertically and horizontally
+ *
+ * Why flexbox?
+ * - Centering content both ways is trivial with flexbox
+ * - Works responsively without media queries for basic centering
+ * - min-height: 100vh ensures full viewport height coverage
+ */
+.message-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-xl);
+  background-color: var(--color-coal-black);
+}
+
+/**
+ * Message Content
+ * Content wrapper with maximum width constraint
+ * Centers text and provides spacing
+ */
+.message-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  padding: var(--space-lg);
+}
+
+/**
+ * Message Text
+ * Large, prominent humorous message
+ * Uses heading font for impact
+ *
+ * Font sizing:
+ * - Mobile: 1.75rem (28px) - readable without being overwhelming
+ * - Tablet: 2rem (32px) - more prominent
+ * - Desktop: 2.5rem (40px) - full impact
+ */
+.message-text {
+  font-family: var(--font-heading);
+  font-size: 1.75rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-aged-whiskey);
+  line-height: var(--line-height-tight);
+  margin-bottom: var(--space-xl);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+/* Tablet breakpoint */
+@media (min-width: 768px) {
+  .message-text {
+    font-size: 2rem;
+  }
+}
+
+/* Desktop breakpoint */
+@media (min-width: 1024px) {
+  .message-text {
+    font-size: 2.5rem;
+  }
+}
+
+/**
+ * Message Timer
+ * Countdown timer display
+ * Prominent but not distracting
+ */
+.message-timer {
+  margin-bottom: var(--space-xl);
+}
+
+.message-timer__text {
+  font-family: var(--font-body);
+  font-size: var(--font-size-lg);
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-regular);
+  letter-spacing: 0.01em;
+}
+
+/**
+ * Message Timer Countdown
+ * Highlighted countdown number
+ * Uses accent color for emphasis
+ */
+.message-timer__countdown {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-tarnished-brass);
+  display: inline-block;
+  min-width: 1.5em;
+  text-align: center;
+}
+
+/**
+ * Message Exit Button
+ * "Get Me Out of Here" button
+ * Styled to match Fan Club exit button pattern
+ *
+ * Design notes:
+ * - High contrast for accessibility
+ * - Large click target for mobile
+ * - Clear hover/focus states
+ * - Smooth transitions for polish
+ */
+.message-exit {
+  display: inline-block;
+  padding: var(--space-md) var(--space-xl);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  background-color: var(--color-iron-gray);
+  border: 2px solid var(--color-aged-whiskey);
+  border-radius: var(--border-radius-base);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: all var(--transition-base);
+  cursor: pointer;
+}
+
+/**
+ * Exit Button Hover State
+ * Inverted colors for clear feedback
+ */
+.message-exit:hover,
+.message-exit:focus {
+  background-color: var(--color-aged-whiskey);
+  color: var(--color-coal-black);
+  border-color: var(--color-aged-whiskey);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+/**
+ * Exit Button Active State
+ * Slight press effect for tactile feedback
+ */
+.message-exit:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Tablet and desktop: larger button */
+@media (min-width: 768px) {
+  .message-exit {
+    font-size: var(--font-size-xl);
+    padding: var(--space-lg) var(--space-xxl);
+  }
+}
+
+/**
+ * Noscript Message
+ * Fallback message when JavaScript is disabled
+ * Provides accessible alternative experience
+ *
+ * Progressive enhancement approach:
+ * - Page works without JavaScript
+ * - Provides clear instructions
+ * - Maintains design consistency
+ */
+.noscript-message {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 600px;
+  width: 90%;
+  padding: var(--space-xl);
+  background-color: var(--color-iron-gray);
+  border: 2px solid var(--color-aged-whiskey);
+  border-radius: var(--border-radius-base);
+  text-align: center;
+  z-index: var(--z-modal);
+}
+
+.noscript-message__text {
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-lg);
+  line-height: var(--line-height-normal);
+}
+
+.noscript-message__button {
+  display: inline-block;
+  padding: var(--space-md) var(--space-xl);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  background-color: var(--color-coal-black);
+  border: 2px solid var(--color-aged-whiskey);
+  border-radius: var(--border-radius-base);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: all var(--transition-base);
+}
+
+.noscript-message__button:hover,
+.noscript-message__button:focus {
+  background-color: var(--color-aged-whiskey);
+  color: var(--color-coal-black);
+}

--- a/assets/js/announcements.js
+++ b/assets/js/announcements.js
@@ -117,6 +117,38 @@ function formatDate(isoDate) {
 // =============================================================================
 
 /**
+ * Maps link text to message type parameter
+ * Converts announcement link text to URL parameter for message.html
+ *
+ * This function creates the mapping between what the user sees
+ * (e.g., "Pre-order Album") and the URL parameter (e.g., "pre-order")
+ * used to select the appropriate humorous message.
+ *
+ * @param {string} linkText - The link text from the announcement
+ * @returns {string} The message type parameter for the URL
+ */
+function getLinkTypeFromText(linkText) {
+  // Convert to lowercase and remove special characters for matching
+  const normalized = linkText.toLowerCase().trim();
+
+  // Map known link text patterns to message types
+  // These correspond to the MESSAGE_CONFIG in message.js
+  if (normalized.includes('pre-order') || normalized.includes('preorder')) {
+    return 'pre-order';
+  }
+  if (normalized.includes('tour') || normalized.includes('dates')) {
+    return 'tour-dates';
+  }
+  if (normalized.includes('spotify') || normalized.includes('listen')) {
+    return 'spotify';
+  }
+
+  // Default to 'read-more' for any other text
+  // This includes "Read More →" and any future variations
+  return 'read-more';
+}
+
+/**
  * Generates HTML for a single announcement card
  * Uses BEM naming convention for CSS classes
  *
@@ -138,11 +170,23 @@ function renderAnnouncementCard(announcement, isHomepage = false) {
   // Format the date for display
   const formattedDate = formatDate(date);
 
-  // Determine the link URL and text
-  // For homepage, we link to the news archive with an anchor
-  // For archive page, we might link externally or use internal anchors
-  const linkUrl = isHomepage ? `news.html#${id}` : (link?.url || `#${id}`);
+  // Determine the link text
+  // For homepage, always show "Read More →"
+  // For archive page, use the link text from data or default to "Read More →"
   const linkText = isHomepage ? 'Read More →' : (link?.text || 'Read More →');
+
+  // Determine the link URL
+  // All announcement links now point to message.html with appropriate type parameter
+  // This creates the humorous dead-end experience described in Phase 10
+  let linkUrl;
+  if (isHomepage) {
+    // Homepage links always go to read-more message
+    linkUrl = 'message.html?type=read-more';
+  } else {
+    // Archive page links map to specific message types based on link text
+    const messageType = getLinkTypeFromText(linkText);
+    linkUrl = `message.html?type=${messageType}`;
+  }
 
   // Build category modifier class for styling
   // This allows different colors/styles per category

--- a/assets/js/message.js
+++ b/assets/js/message.js
@@ -1,0 +1,349 @@
+/**
+ * MESSAGE MODULE
+ * Handles humorous dead-end message pages with timer and redirect
+ *
+ * This module demonstrates:
+ * - URL parameter parsing (reading query strings)
+ * - Timer management with setInterval/clearInterval
+ * - DOM manipulation for dynamic content
+ * - Progressive enhancement (works without JavaScript via noscript)
+ * - Error handling for invalid/missing parameters
+ * - Cleanup on navigation (clearing timers)
+ *
+ * User Experience Flow:
+ * 1. User clicks announcement link → navigates to message.html?type=something
+ * 2. JavaScript reads the 'type' parameter from the URL
+ * 3. Appropriate humorous message is displayed
+ * 4. 7-second countdown timer starts
+ * 5. After 7 seconds, auto-redirect to news.html
+ * 6. "Get Me Out of Here" button provides immediate exit
+ */
+
+// =============================================================================
+// MESSAGE CONFIGURATION
+// =============================================================================
+
+/**
+ * Message configuration object
+ * Maps URL parameter types to humorous messages
+ *
+ * This object uses key-value pairs where:
+ * - Key: the 'type' parameter from the URL
+ * - Value: the humorous message to display
+ *
+ * Based on discovered link types in announcements.json:
+ * - "Read More →" (default for announcements without links)
+ * - "Pre-order Album"
+ * - "View Tour Dates"
+ * - "Listen on Spotify"
+ */
+const MESSAGE_CONFIG = {
+  // Default message for "Read More" links
+  'read-more': "Well... there's really nothing more to add so... goodbye",
+
+  // Pre-order album message (humorous rejection)
+  'pre-order': "Yeah, as if. But feel free to send cash anyway",
+
+  // Tour dates message (personal invitation)
+  'tour-dates': "Call us. We'll come visit",
+
+  // Spotify message (absurdist alternative)
+  'spotify': "Best to do what we do. Close your eyes and just imagine what it sounds like",
+
+  // Fallback for unknown types
+  'default': "You've wandered into uncharted territory. Impressive. But there's nothing here."
+};
+
+/**
+ * Timer configuration
+ * Constants for countdown timer behavior
+ */
+const COUNTDOWN_DURATION = 7; // seconds
+const REDIRECT_URL = 'news.html';
+
+// =============================================================================
+// URL PARAMETER PARSING
+// =============================================================================
+
+/**
+ * Reads the 'type' parameter from the current page URL
+ *
+ * URL Structure Example: message.html?type=read-more
+ * - The '?' starts the query string
+ * - Parameters are in format: name=value
+ * - Multiple parameters separated by '&'
+ *
+ * URLSearchParams is a built-in browser API that makes it easy
+ * to work with query strings without manual string parsing.
+ *
+ * @returns {string} The type parameter value (e.g., 'read-more')
+ */
+function getMessageType() {
+  // window.location.search returns the query string portion of the URL
+  // Example: if URL is "message.html?type=read-more", this returns "?type=read-more"
+  const queryString = window.location.search;
+
+  console.log('🔍 Reading URL parameters:', queryString);
+
+  // URLSearchParams parses the query string into a searchable object
+  // It automatically handles URL decoding (e.g., %20 → space)
+  const params = new URLSearchParams(queryString);
+
+  // get() method retrieves the value of a specific parameter
+  // Returns null if the parameter doesn't exist
+  const type = params.get('type');
+
+  console.log('📝 Message type:', type || 'none (will use default)');
+
+  // Return the type, or null if not found
+  // The calling function will handle the null case
+  return type;
+}
+
+/**
+ * Gets the appropriate message based on the type parameter
+ * Falls back to default message if type is invalid or missing
+ *
+ * @param {string|null} type - The message type from URL parameter
+ * @returns {string} The humorous message to display
+ */
+function getMessageForType(type) {
+  // If no type provided, use default
+  if (!type) {
+    console.log('⚠️ No type parameter found, using default message');
+    return MESSAGE_CONFIG.default;
+  }
+
+  // Check if we have a message for this type
+  // The 'in' operator checks if a property exists in an object
+  if (type in MESSAGE_CONFIG) {
+    console.log(`✅ Found message for type: ${type}`);
+    return MESSAGE_CONFIG[type];
+  }
+
+  // Type exists but we don't have a message for it
+  console.log(`⚠️ Unknown message type: ${type}, using default`);
+  return MESSAGE_CONFIG.default;
+}
+
+// =============================================================================
+// DOM MANIPULATION
+// =============================================================================
+
+/**
+ * Updates the message text on the page
+ *
+ * This function finds the message element and replaces its content
+ * with the appropriate humorous message based on the URL parameter
+ */
+function displayMessage() {
+  console.log('💬 Displaying message...');
+
+  // Find the message text element by its ID
+  const messageElement = document.getElementById('message-text');
+
+  // Defensive programming: check if element exists
+  // This prevents errors if the HTML structure changes
+  if (!messageElement) {
+    console.error('❌ Message element not found!');
+    return;
+  }
+
+  // Get the message type from the URL
+  const type = getMessageType();
+
+  // Get the appropriate message for this type
+  const message = getMessageForType(type);
+
+  // Update the element's text content
+  // textContent is safer than innerHTML as it prevents XSS attacks
+  // (though in this case we control all the messages, so it's not a risk)
+  messageElement.textContent = message;
+
+  console.log('✅ Message displayed');
+}
+
+// =============================================================================
+// COUNTDOWN TIMER
+// =============================================================================
+
+/**
+ * Global timer variable
+ * We store the interval ID so we can clear it later
+ *
+ * Why global? We need to access this from multiple functions:
+ * - startCountdown() sets it
+ * - cleanup() clears it
+ * - The exit button handler clears it
+ */
+let countdownInterval = null;
+
+/**
+ * Starts the countdown timer and handles auto-redirect
+ *
+ * This function uses setInterval to update the countdown every second.
+ * setInterval is a JavaScript function that repeatedly calls a function
+ * at a specified time interval (in milliseconds).
+ *
+ * Timer Flow:
+ * 1. Display initial countdown (7)
+ * 2. Every second: decrement and update display
+ * 3. When reaches 0: stop timer and redirect
+ */
+function startCountdown() {
+  console.log('⏱️ Starting countdown timer...');
+
+  // Find the countdown display element
+  const countdownElement = document.getElementById('timer-countdown');
+
+  if (!countdownElement) {
+    console.error('❌ Countdown element not found!');
+    return;
+  }
+
+  // Initialize countdown value
+  let secondsRemaining = COUNTDOWN_DURATION;
+
+  // Update display with initial value
+  countdownElement.textContent = secondsRemaining;
+
+  // setInterval calls the provided function every X milliseconds
+  // 1000 milliseconds = 1 second
+  // It returns an interval ID that we can use to stop it later
+  countdownInterval = setInterval(() => {
+    // Decrement the seconds remaining
+    secondsRemaining--;
+
+    console.log(`⏳ Countdown: ${secondsRemaining} seconds remaining`);
+
+    // Update the display
+    countdownElement.textContent = secondsRemaining;
+
+    // Check if countdown has finished
+    if (secondsRemaining <= 0) {
+      console.log('🚀 Countdown complete! Redirecting...');
+
+      // Stop the interval from running again
+      // clearInterval stops a setInterval timer
+      clearInterval(countdownInterval);
+
+      // Redirect to the news page
+      // window.location.href changes the current page URL
+      // This is equivalent to clicking a link
+      window.location.href = REDIRECT_URL;
+    }
+  }, 1000); // Run every 1000ms (1 second)
+
+  console.log('✅ Countdown timer started');
+}
+
+// =============================================================================
+// EXIT BUTTON HANDLER
+// =============================================================================
+
+/**
+ * Sets up the exit button to stop the timer and redirect immediately
+ *
+ * Without this cleanup, the timer would keep running even after
+ * the user clicks the exit button, which could cause issues.
+ */
+function setupExitButton() {
+  console.log('🚪 Setting up exit button...');
+
+  const exitButton = document.getElementById('message-exit');
+
+  if (!exitButton) {
+    console.error('❌ Exit button not found!');
+    return;
+  }
+
+  // Add click event listener
+  // We use addEventListener instead of onclick for better practice
+  // addEventListener allows multiple handlers and better control
+  exitButton.addEventListener('click', (event) => {
+    console.log('👆 Exit button clicked');
+
+    // Stop the countdown timer
+    // This prevents the timer from continuing after we leave the page
+    if (countdownInterval) {
+      clearInterval(countdownInterval);
+      console.log('⏹️ Timer stopped');
+    }
+
+    // Note: We don't need to preventDefault() here because
+    // the button is already an <a> tag with href="news.html"
+    // The browser will naturally navigate to that URL
+  });
+
+  console.log('✅ Exit button ready');
+}
+
+// =============================================================================
+// CLEANUP
+// =============================================================================
+
+/**
+ * Cleanup function to stop the timer when the page unloads
+ *
+ * This is good practice to prevent memory leaks and unexpected behavior.
+ * Even though the page is unloading, it's important to clean up timers.
+ */
+function cleanup() {
+  if (countdownInterval) {
+    console.log('🧹 Cleaning up timer on page unload');
+    clearInterval(countdownInterval);
+    countdownInterval = null;
+  }
+}
+
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+/**
+ * Initializes the message page
+ * Called when the DOM is ready
+ *
+ * Initialization steps:
+ * 1. Display the appropriate message based on URL parameter
+ * 2. Start the countdown timer
+ * 3. Set up the exit button handler
+ * 4. Register cleanup handler for page unload
+ */
+function init() {
+  console.log('🚀 Initializing message page...');
+
+  // Display the message
+  displayMessage();
+
+  // Start the countdown timer
+  startCountdown();
+
+  // Set up exit button
+  setupExitButton();
+
+  // Register cleanup handler
+  // beforeunload fires when the user is about to leave the page
+  // This could be from clicking a link, closing the tab, or the timer redirect
+  window.addEventListener('beforeunload', cleanup);
+
+  console.log('✅ Message page initialized successfully');
+}
+
+// =============================================================================
+// AUTO-INITIALIZATION
+// =============================================================================
+
+/**
+ * Wait for the DOM to be fully loaded before running our code
+ *
+ * This ensures all HTML elements exist before we try to manipulate them.
+ * We use the same pattern as announcements.js for consistency.
+ */
+if (document.readyState === 'loading') {
+  // DOM is still loading, wait for the DOMContentLoaded event
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  // DOM is already loaded (script was loaded late), run immediately
+  init();
+}

--- a/message.html
+++ b/message.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="A message from tHE dURT nURS' - You've reached a dead end">
+  <meta name="robots" content="noindex, nofollow">
+
+  <title>Message - tHE dURT nURS'</title>
+
+  <!-- CSS Architecture: Load in order of specificity -->
+  <link rel="stylesheet" href="assets/css/reset.css">
+  <link rel="stylesheet" href="assets/css/variables.css">
+  <link rel="stylesheet" href="assets/css/layout.css">
+  <link rel="stylesheet" href="assets/css/components.css">
+
+  <!-- Google Fonts: Oswald (headers) + Merriweather (body) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Merriweather:wght@300;400;700&display=swap" rel="stylesheet">
+
+  <!-- Favicon (placeholder - add actual favicon later) -->
+  <link rel="icon" type="image/png" href="assets/images/favicon.png">
+</head>
+<body>
+
+  <!--
+    MESSAGE PAGE
+    Full-page humorous message with timer and exit button
+    This page is intentionally minimal - no header or footer navigation
+    to emphasize the "dead-end" experience
+  -->
+  <main class="message-container" role="main">
+    <div class="message-content">
+
+      <!--
+        MESSAGE TEXT
+        Populated by JavaScript based on URL parameter
+        Default message shown for progressive enhancement
+      -->
+      <h1 class="message-text" id="message-text" aria-live="polite">
+        Well... there's really nothing more to add so... goodbye
+      </h1>
+
+      <!--
+        COUNTDOWN TIMER
+        Shows seconds remaining before auto-redirect
+        Hidden when JavaScript is disabled (progressive enhancement)
+      -->
+      <div class="message-timer" id="message-timer" aria-live="polite" aria-atomic="true">
+        <p class="message-timer__text">
+          Redirecting in <span class="message-timer__countdown" id="timer-countdown">7</span> seconds...
+        </p>
+      </div>
+
+      <!--
+        EXIT BUTTON
+        Provides immediate escape route back to news page
+        Styled to match Fan Club exit button
+      -->
+      <a href="news.html" class="message-exit" id="message-exit">
+        Get Me Out of Here
+      </a>
+
+    </div>
+  </main>
+
+  <!--
+    PROGRESSIVE ENHANCEMENT FALLBACK
+    Displayed when JavaScript is disabled
+    Provides accessible alternative experience
+  -->
+  <noscript>
+    <div class="noscript-message">
+      <p class="noscript-message__text">
+        Well, this is awkward. JavaScript is required for the full comedic timing experience.
+      </p>
+      <a href="news.html" class="button noscript-message__button">
+        Back to News
+      </a>
+    </div>
+
+    <!--
+      Hide timer when JavaScript is disabled
+      Timer only works with JavaScript, so we hide it to avoid confusion
+    -->
+    <style>
+      .message-timer {
+        display: none;
+      }
+    </style>
+  </noscript>
+
+  <!--
+    JAVASCRIPT MODULE
+    Handles message selection, timer, and redirect
+    Progressive enhancement: page still works without this
+  -->
+  <script src="assets/js/message.js"></script>
+
+</body>
+</html>

--- a/news.html
+++ b/news.html
@@ -150,7 +150,7 @@
                 <p>Pre-order the chaos now. Your eardrums will thank you. Or sue us. Probably sue us.</p>
               </div>
 
-              <a href="#listen" class="announcement-card__link" aria-label="Read more about Release the Kraken!">
+              <a href="message.html?type=pre-order" class="announcement-card__link" aria-label="Read more about Release the Kraken!">
                 Pre-order Album
               </a>
             </article>
@@ -174,7 +174,7 @@
                 <p>Special thanks to our AI overlords for helping us fake competence in modern web development.</p>
               </div>
 
-              <a href="#002" class="announcement-card__link" aria-label="Read more about New Website, Same Old Disappointment">
+              <a href="message.html?type=read-more" class="announcement-card__link" aria-label="Read more about New Website, Same Old Disappointment">
                 Read More →
               </a>
             </article>
@@ -198,7 +198,7 @@
                 <p>Ports include: Port Anne, Port Royal, Port Blandford, Van Tupes Tawny Port, and two surprise locations we haven't figured out yet. Stay tuned for actual dates once we consult a calendar.</p>
               </div>
 
-              <a href="#tour" class="announcement-card__link" aria-label="Read more about Fall Tour: Six Cities, Eight Bars, Zero Rehearsals">
+              <a href="message.html?type=tour-dates" class="announcement-card__link" aria-label="Read more about Fall Tour: Six Cities, Eight Bars, Zero Rehearsals">
                 View Tour Dates
               </a>
             </article>


### PR DESCRIPTION
Transform non-functioning announcement card links into humorous dead-end experiences with custom messages, timer-based redirect, and exit button.

New Files:
- message.html: Full-page message display with responsive design
- assets/js/message.js: Timer and redirect logic with comprehensive comments

Modified Files:
- assets/css/components.css: Added message page component styles
- assets/js/announcements.js: Updated to generate message.html links with type parameters
- news.html: Updated noscript section links to use message.html

Features:
- URL parameter-based message selection (type=read-more, pre-order, tour-dates, spotify)
- 7-second countdown timer with auto-redirect to news.html
- "Get Me Out of Here" exit button for immediate return
- Progressive enhancement (works without JavaScript via noscript)
- Responsive design matching existing design system
- WCAG 2.1 AA accessibility compliance
- Educational inline comments throughout

Message Types Implemented:
- read-more: "Well... there's really nothing more to add so... goodbye"
- pre-order: "Yeah, as if. But feel free to send cash anyway"
- tour-dates: "Call us. We'll come visit"
- spotify: "Best to do what we do. Close your eyes and just imagine what it sounds like"
- default: Fallback for unknown types

All announcement links now navigate to humorous message pages that maintain the band's self-aware absurdist tone while providing a delightful user experience.