### PR TITLE
Fix hero logo centering on mobile portrait (iPhone 13)

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -253,6 +253,22 @@ section {
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.8);
 }
 
+/* Mobile portrait: Aggressive fix for logo centering */
+@media (max-width: 767px) {
+  .hero .container {
+    padding-left: var(--space-xs);   /* Reduce from 16px to 8px */
+    padding-right: var(--space-xs);
+  }
+
+  .hero__content {
+    padding: var(--space-sm);  /* Reduce from 48px to 16px */
+  }
+
+  .hero__logo {
+    max-width: 280px;  /* Reduce from 400px to ensure centering room */
+  }
+}
+
 @media (min-width: 768px) {
   .hero {
     min-height: 70vh;


### PR DESCRIPTION
Problem: Logo appeared off-center/shifted right on 390px viewport Root cause: Excessive padding on .hero__content (48px) + .container (16px) left only 262px for content, forcing logo to fill completely with no room for margin: 0 auto to center it.

Solution:
- Reduce .hero .container padding: 16px → 8px on mobile
- Reduce .hero__content padding: 48px → 16px on mobile
- Reduce .hero__logo max-width: 400px → 280px on mobile

Result: Logo now has 62px of extra horizontal space (31px margin each side) for proper centering at 390px viewport width.

Affects: index.html only (other pages use .hero--variant classes)