### PR TITLE
Fix contact page horizontal overflow on mobile portrait

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2620,6 +2620,20 @@ p.origin-placeholder {
   }
 }
 
+/* Mobile: Make contact button responsive to prevent overflow */
+@media (max-width: 767px) {
+  .contact-button {
+    min-width: 0;
+    width: 100%;
+    max-width: 280px;  /* Cap at desktop size */
+    padding: var(--space-md) var(--space-xl);  /* Slightly reduce padding: 24px 48px */
+  }
+
+  .contact-card {
+    padding: var(--space-2xl) var(--space-md);  /* Reduce horizontal padding: 64px 24px */
+  }
+}
+
 /*
   CONTACT CONTEXT SECTION
   What types of inquiries to send


### PR DESCRIPTION
Resolves issue where contact.html content was cropped on right side in portrait orientation on mobile devices (iPhone 13, 390px viewport).

Root cause:
- .contact-button had fixed min-width: 280px
- Nested in .container (16px padding) + .contact-card (48px padding)
- Total available width: 390px - 32px - 96px = 262px
- Button requirement: 280px
- Result: 18px overflow beyond viewport

Fix applied:
- Added mobile-specific media query (@max-width: 767px)
- .contact-button: Removed fixed min-width, made responsive with width: 100% capped at max-width: 280px
- .contact-card: Reduced horizontal padding from 48px to 24px
- Slightly reduced button padding for better mobile proportions

Testing:
- iPhone SE (375px): 295px available > 280px ✅
- iPhone 13 (390px): 310px available > 280px ✅
- Pixel 7 (393px): 313px available > 280px ✅
- iPhone 14 Pro Max (430px): 350px available > 280px ✅
- Desktop (≥768px): Original design preserved ✅

File modified: assets/css/components.css (lines 2623-2635)